### PR TITLE
Refactor

### DIFF
--- a/dvd/dvd_dump.ixx
+++ b/dvd/dvd_dump.ixx
@@ -606,23 +606,23 @@ export bool redumper_dump_dvd(Context &ctx, const Options &options, DumpMode dum
                 print_ss_structure(*ss_layer_descriptor, layer_descriptor);
                 LOG("");
 
-                int32_t xbox_layer0_last = sign_extend<24>(endian_swap(ss_layer_descriptor->layer0_end_sector));
+                int32_t xbox_layer0_last = sign_extend<24>(endian_swap(ss_layer_descriptor.layer0_end_sector));
 
                 LOG("layer break: {}", xbox_layer0_last + 1 - lba_first);
                 LOG("");
 
                 // extract security sector ranges
                 bool is_xgd1 = xgd_type == XGD_Type::XGD1;
-                uint8_t num_ss_regions = ss_layer_descriptor->media_specific[1632 - 17];
+                uint8_t num_ss_regions = ss_layer_descriptor.media_specific[1632 - 17];
                 // partial pre-compute of conversion to Layer 1
                 const uint32_t layer1_offset = (xbox_layer0_last * 2) - 0x030000 + 1;
 
                 for(int ss_pos = 1633, i = 0; i < num_ss_regions; ss_pos += 9, i++)
                 {
-                    uint32_t start_psn = ((uint32_t)ss_layer_descriptor->media_specific[ss_pos + 3 - 17] << 16) | ((uint32_t)ss_layer_descriptor->media_specific[ss_pos + 4 - 17] << 8)
-                                       | (uint32_t)ss_layer_descriptor->media_specific[ss_pos + 5 - 17];
-                    uint32_t end_psn = ((uint32_t)ss_layer_descriptor->media_specific[ss_pos + 6 - 17] << 16) | ((uint32_t)ss_layer_descriptor->media_specific[ss_pos + 7 - 17] << 8)
-                                     | (uint32_t)ss_layer_descriptor->media_specific[ss_pos + 8 - 17];
+                    uint32_t start_psn = ((uint32_t)ss_layer_descriptor.media_specific[ss_pos + 3 - 17] << 16) | ((uint32_t)ss_layer_descriptor.media_specific[ss_pos + 4 - 17] << 8)
+                                       | (uint32_t)ss_layer_descriptor.media_specific[ss_pos + 5 - 17];
+                    uint32_t end_psn = ((uint32_t)ss_layer_descriptor.media_specific[ss_pos + 6 - 17] << 16) | ((uint32_t)ss_layer_descriptor.media_specific[ss_pos + 7 - 17] << 8)
+                                     | (uint32_t)ss_layer_descriptor.media_specific[ss_pos + 8 - 17];
                     if((i < 8 && is_xgd1) || (i == 0 && !is_xgd1))
                     {
                         // Layer 0
@@ -909,8 +909,8 @@ export bool redumper_dump_dvd(Context &ctx, const Options &options, DumpMode dum
         // write L1 middle/filler padding
         std::vector<uint8_t> zeroes(sectors_at_once * FORM1_DATA_SIZE);
 
-        int32_t xbox_lba_first = sign_extend<24>(endian_swap(ss_layer_descriptor->data_start_sector));
-        int32_t xbox_layer0_last = sign_extend<24>(endian_swap(ss_layer_descriptor->layer0_end_sector));
+        int32_t xbox_lba_first = sign_extend<24>(endian_swap(ss_layer_descriptor.data_start_sector));
+        int32_t xbox_layer0_last = sign_extend<24>(endian_swap(ss_layer_descriptor.layer0_end_sector));
 
         uint32_t end_l1_middle = sectors_count + xbox_lba_first - xbox_layer0_last - l1_video_start;
         if(xgd_type == XGD_Type::XGD3)

--- a/dvd/dvd_dump.ixx
+++ b/dvd/dvd_dump.ixx
@@ -596,7 +596,7 @@ export bool redumper_dump_dvd(Context &ctx, const Options &options, DumpMode dum
                 sectors_count = sector_last + 1;
 
                 LOG("disc structure:");
-                print_ss_structure(*ss_layer_descriptor, *layer_descriptor);
+                print_ss_structure(*ss_layer_descriptor, layer_descriptor);
                 LOG("");
 
                 uint32_t xbox_layer0_last = sign_extend<24>(endian_swap(ss_layer_descriptor->layer0_end_sector));

--- a/dvd/dvd_dump.ixx
+++ b/dvd/dvd_dump.ixx
@@ -242,7 +242,7 @@ void print_ss_structure(const READ_DVD_STRUCTURE_LayerDescriptor &layer_descript
     LOG("{}layer {} {{ {} }}", std::string(2, ' '), 0, types);
     LOG("{}data {{ LBA: [{} .. {}], length: {}, hLBA: [0x{:06X} .. 0x{:06X}] }}", indent, lba_first, lba_last, layer0_size, lba_first_raw, lba_last_raw);
     if(layer0_last)
-        LOG("{}data layer 0 last {{ LBA: {}, hLBA: 0x{:06X} }}", indent, ss_layer0_last, layer0_last_raw);
+        LOG("{}data layer 0 last {{ LBA: {}, hLBA: 0x{:06X} }}", indent, layer0_last, layer0_last_raw);
     LOG("{}book type: {}", indent, BOOK_TYPE[layer_descriptor.book_type]);
     LOG("{}part version: {}", indent, layer_descriptor.part_version);
     if(layer_descriptor.disc_size < 2)

--- a/dvd/dvd_dump.ixx
+++ b/dvd/dvd_dump.ixx
@@ -233,8 +233,8 @@ void print_ss_structure(const READ_DVD_STRUCTURE_LayerDescriptor &layer_descript
     uint32_t lba_last_raw = endian_swap(pfi_layer_descriptor.data_end_sector);
     uint32_t layer0_last_raw = endian_swap(layer_descriptor.layer0_end_sector);
 
-    uint32_t lba_first = sign_extend<24>(pfi_lba_first_raw);
-    uint32_t lba_last = sign_extend<24>(pfi_lba_last_raw);
+    uint32_t lba_first = sign_extend<24>(lba_first_raw);
+    uint32_t lba_last = sign_extend<24>(lba_last_raw);
     uint32_t layer0_last = sign_extend<24>(layer0_last_raw);
 
     uint32_t layer0_size = layer0_last - lba_first + 1;

--- a/dvd/dvd_dump.ixx
+++ b/dvd/dvd_dump.ixx
@@ -474,7 +474,7 @@ export bool redumper_dump_dvd(Context &ctx, const Options &options, DumpMode dum
                     std::vector<uint8_t> security_sectors(0x800);
 
                     // keep retrying get security sectors
-                    for(uint32_t i = 0; ; i++)
+                    for(uint32_t i = 0;; i++)
                     {
                         status = cmd_kreon_get_security_sectors(*ctx.sptd, security_sectors);
                         if(!status.status_code)

--- a/utils/xbox.ixx
+++ b/utils/xbox.ixx
@@ -11,7 +11,7 @@ namespace gpsxre
 
 export enum class XGD_Type : uint8_t
 {
-    UNKNOWN,
+    NONE,
     XGD1,
     XGD2,
     XGD3
@@ -19,8 +19,9 @@ export enum class XGD_Type : uint8_t
 
 export XGD_Type get_xgd_type(std::vector<uint8_t> &ss)
 {
+    // TODO: Further validation on SS
     if(ss.size() != 2048)
-        return XGD_Type::UNKNOWN;
+        return XGD_Type::NONE;
 
     // Concatenate the last three values
     uint32_t xgd_type = ((uint32_t)ss[13] << 16) | ((uint32_t)ss[14] << 8) | ss[15];
@@ -35,7 +36,7 @@ export XGD_Type get_xgd_type(std::vector<uint8_t> &ss)
     case 0x238E0F:
         return XGD_Type::XGD3;
     default:
-        return XGD_Type::UNKNOWN;
+        return XGD_Type::NONE;
     }
 }
 


### PR DESCRIPTION
A bunch of refactoring, let me know what you think.
The incorrect PFI (L1 Video partition) disc structure and layer break now don't get printed, and a combined disc structure is printed instead.
The zeroing/L1 Video dumping should also now be transparent to the user, once it finishes the game partition the progress should go beyond the initial sector count.
I've tried to remove as many of the variables from the higher-up scope, but had to introduce the entire ss_layer_descriptor. 
I'd like to add some more validation to the XGD detection, as well as add a custom SS struct rather than access the media_specific array like I currently am.

I haven't tested this for regressions, as I don't own a Kreon drive.