### PR TITLE
Proper Kreon lock/unlock

### DIFF
--- a/dvd/dvd_dump.ixx
+++ b/dvd/dvd_dump.ixx
@@ -839,12 +839,6 @@ export bool redumper_dump_dvd(Context &ctx, const Options &options, DumpMode dum
                 status = cmd_kreon_set_lock_state(*ctx.sptd, KREON_LockState::LOCKED);
                 if(status.status_code)
                     throw_line("failed to set lock state, SCSI ({})", SPTD::StatusMessage(status));
-                uint32_t locked_sector_last;
-                status = cmd_read_capacity(*ctx.sptd, locked_sector_last, block_length, false, 0, false);
-                if(status.status_code)
-                    throw_line("failed to read capacity, SCSI ({})", SPTD::StatusMessage(status));
-                if(locked_sector_last == sector_last)
-                    throw_line("failed to set lock state, cannot read L1 video. dumping on linux?");
                 if(options.verbose)
                     LOG_R("locked kreon drive at sector: {}", s);
                 kreon_locked = true;


### PR DESCRIPTION
- Properly check for failed DMI SCSI return status
- Re-unlock drive before quitting (return drive to initial state)
- Try unlock the drive at the start if Kreon firmware detected.

It is important to re-unlock the drive, as attempting to dump the same disc twice without ejecting and re-inserting will not detect an XGD and only dump the video portion. Unlocking the drive at the end returns it to how the drive was initially.

Our XGD detection relies on the drive being unlocked at the start (sector count mismatch with PFI), and this works because the firmware unlocks the drive when an Xbox disc is inserted. However we shouldn't assume that, so we try unlock at the start.